### PR TITLE
CAConfig variable used instead of CAType

### DIFF
--- a/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.psm1
+++ b/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.psm1
@@ -82,7 +82,7 @@ Function Get-TargetResource
 
     return @{
         Ensure     = $Ensure
-        CAType     = $CAType
+        CAConfig     = $CAConfig
         Credential = $Credential
     }
 } # Function Get-TargetResource
@@ -207,7 +207,7 @@ Function Test-TargetResource
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($LocalizedData.TestingAdcsWebEnrollmentStatusMessage -f $CAType)
+            $($LocalizedData.TestingAdcsWebEnrollmentStatusMessage -f $CAConfig)
         ) -join '' )
 
     $ADCSParams = @{} + $PSBoundParameters


### PR DESCRIPTION
With CAType being used as the variable, when Get-DSCConfiguration was run, the below error was received as it wasn't available. Replacing CAType with CAConfig resolves this issue and Get-DSCConfiguration is run successfully without error.
---------------------
Get-DscConfiguration : The PowerShell DSC resource  returned results that are not valid from Get-TargetResource. The CAType key is not a valid property 
in the corresponding DSC resource schema file. The results from Get-TargetResource must be in a Hashtable format. The keys in the Hashtable must be the 
same as the properties in the corresponding DSC resource schema file.
    + CategoryInfo          : InvalidResult: (MSFT_DSCLocalConfigurationManager:root/Microsoft/...gurationManager) [Get-DscConfiguration], CimException
    + FullyQualifiedErrorId : GetOperationResultInvalidResultFormat,Get-DscConfiguration
---------------------